### PR TITLE
increase timeouts to stop the 500 errors in acceptance tests

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,8 +6,8 @@ management.security.enabled=${ACT_GATEWAY_MANAGEMENT_SECURITY:false}
 spring.rabbitmq.host=${ACT_RABBITMQ_HOST:rabbitmq}
 eureka.client.serviceUrl.defaultZone=${ACT_EUREKA_URL:http://activiti-cloud-registry:8761/eureka/}
 
-hystrix.command.default.execution.timeout.enabled=${ACT_GATEWAY_HYSTRIX_TIMEOUT_ENABLED:false}
-hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=${ACT_GATEWAY_HYSTRIX_TIMEOUT:210000}
+hystrix.command.default.execution.timeout.enabled=${ACT_GATEWAY_HYSTRIX_TIMEOUT_ENABLED:true}
+hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=${ACT_GATEWAY_HYSTRIX_TIMEOUT:60000}
 
 zuul.sensitive-headers=${ACT_GATEWAY_SENSITIVE_HEADERS:Cookie,Set-Cookie}
 
@@ -34,3 +34,11 @@ keycloak.cors-allowed-headers=${ACT_KEYCLOAK_CORS_HEADERS:Access-Control-Allow-O
 keycloak.ssl-required=${ACT_KEYCLOAK_SSL_REQUIRED:none}
 
 management.endpoints.web.exposure.include=health,routes,metrics,info
+
+zuul.host.connect-timeout-millis=5000
+zuul.host.socket-timeout-millis=60000
+
+zuul.ribbon-isolation-strategy=thread
+        
+ribbon.ConnectTimeout=3000
+ribbon.ReadTimeout=60000


### PR DESCRIPTION
When working on https://github.com/Activiti/Activiti/issues/1887 was finding that intermittent 500 errors would affect the acceptance tests and tests that initially failed would usually work on a second run. Also observable with postman.

The behaviour matches https://stackoverflow.com/questions/42841261/flickering-zuul-timeoutexceptions-using-enablezuulproxy-with-spring-boot-and-eu but the stacktrace matches https://stackoverflow.com/questions/49777627/com-netflix-zuul-exception-zuulexception-forwarding-error-while-calling-microse

I think there's more than one kind of timeout responsible. We're using a filter for the keycloak token so that can timeout. But we've also got actions that can take a while to complete (starting a process instance was/is frequently affected). And we've got services behind the gateway that call on to other services (the modeling functions).

Increasing some timeouts seem to make the issue less frequent of a problem but with all of the increased I can run the acceptance tests without hitting the 500s. Needing to increase more than one of the timeouts is consistent with https://github.com/spring-cloud/spring-cloud-netflix/issues/2606