### PR TITLE
add spring cloud kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,17 @@
 
 Alfresco API Gateway
 
+This project is using the Spring Cloud Gateway project along the Spring Cloud Kubernetes project to create dynamic routes
+to the services registered inside a Kubernetes namespace. 
+
+The main goal of this project is to provide a single entrypoint for your client applications to interact with a set of backend services.
+
 Currently spring.cloud.gateway classes are overridden in the project due to these issues:
 
 https://github.com/spring-cloud/spring-cloud-gateway/issues/229
 and
 https://github.com/spring-cloud/spring-cloud-gateway/issues/314
+
+Currently discovery of routes only works on startup and if a new app is added then a POST to /application/gateway/refresh is necessary. It's not clear how to resolve this.
+
+Discovery is also limited to the current namespace.

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,13 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-kubernetes-dependencies</artifactId>
+        <version>${spring.cloud.k8s.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
 		</dependencies>
 	</dependencyManagement>
   <dependencies>
@@ -49,6 +56,14 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-gateway</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-kubernetes-discovery</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-kubernetes-ribbon</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,13 @@
 spring:
   application.name: gateway
+  cloud:
+    gateway:
+      discovery:
+        locator:
+          enabled: true
+          url-expression: "'http://'+serviceId"
+      x-forwarded:
+        prefixEnabled: true
 # log level seems to be needed explicitly
 logging:
   level:


### PR DESCRIPTION
This doesn't include any changes to the deployment configuration as that is separated into PR https://github.com/Alfresco/alfresco-api-gateway/pull/30 

But a ServiceAccount with read-level roles is necessary in order to use Spring Cloud Kubernetes Discovery. See https://github.com/Alfresco/alfresco-api-gateway/pull/30/files#diff-4efeeb839d67030fafbd0d1edd30cf11